### PR TITLE
Use  a list of  <goal>s instead of a set

### DIFF
--- a/prover/drivers/base.md
+++ b/prover/drivers/base.md
@@ -3,7 +3,7 @@ Configuration
 
 The configuration consists of a assoc-commutative bag of goals. Only goals
 marked `<active>` are executed to control the non-determinism in the system. The
-`<claim>` cell contains the Matching Logic Pattern for which we are searching for a
+`<k>` cell contains the Matching Logic Pattern for which we are searching for a
 proof. The `<strategy>` cell contains an imperative language that controls which
 (high-level) proof rules are used to complete the goal. The `<trace>` cell
 stores a log of the strategies used in the search of a proof and other debug
@@ -21,20 +21,18 @@ module PROVER-CONFIGURATION
 
   configuration
       <prover>
-        <k> $COMMANDLINE:CommandLine ~> $PGM:Pgm </k>
         <exit-code exit=""> 1 </exit-code>
         <goals>
           <goal multiplicity="*" type="Set" format="%1%i%n%2, %3, %4%n%5%n%6%n%7%n%8%n%d%9">
             <active format="active: %2"> true:Bool </active>
             <id format="id: %2"> .K </id>
             <parent format="parent: %2"> .K </parent>
-            <claim> .K </claim>
+            <k> $COMMANDLINE:CommandLine ~> $PGM:Pgm </k>
             <strategy> .K </strategy>
             <expected> .K </expected>
             <local-context>
               <local-decl multiplicity="*" type="Set">  .K </local-decl>
             </local-context>
-
             <trace> .K </trace>
           </goal>
         </goals>

--- a/prover/drivers/base.md
+++ b/prover/drivers/base.md
@@ -1,13 +1,13 @@
 Configuration
 =============
 
-The configuration consists of a assoc-commutative bag of goals. Only goals
-marked `<active>` are executed to control the non-determinism in the system. The
-`<k>` cell contains the Matching Logic Pattern for which we are searching for a
-proof. The `<strategy>` cell contains an imperative language that controls which
-(high-level) proof rules are used to complete the goal. The `<trace>` cell
-stores a log of the strategies used in the search of a proof and other debug
-information. Eventually, this could be used for constructing a proof object.
+The configuration consists of a list of goals. The first goal is considered
+active. The `<k>` cell contains the Matching Logic Pattern for which we are
+searching for a proof. The `<strategy>` cell contains an imperative language
+that controls which (high-level) proof rules are used to complete the goal. The
+`<trace>` cell stores a log of the strategies used in the search of a proof and
+other debug information. Eventually, this could be used for constructing a proof
+object.
 
 ```k
 module PROVER-CONFIGURATION
@@ -23,8 +23,7 @@ module PROVER-CONFIGURATION
       <prover>
         <exit-code exit=""> 1 </exit-code>
         <goals>
-          <goal multiplicity="*" type="Set" format="%1%i%n%2, %3, %4%n%5%n%6%n%7%n%8%n%d%9">
-            <active format="active: %2"> true:Bool </active>
+          <goal multiplicity="*" type="List" format="%1%i%n%2, %3%n%4%n%5n%6%n%7%n%d%8">
             <id format="id: %2"> .K </id>
             <parent format="parent: %2"> .K </parent>
             <k> $COMMANDLINE:CommandLine ~> $PGM:Pgm </k>

--- a/prover/drivers/base.md
+++ b/prover/drivers/base.md
@@ -87,6 +87,16 @@ module DRIVER-BASE
   imports LOAD-NAMED-RULES
 
   rule <k> .CommandLine => .K ... </k>
+
+  rule <goals>
+         <goal>
+           <id> .K </id>
+           <expected> .K </expected>
+           <strategy> .K </strategy>
+           ...
+         </goal>
+       </goals>
+       <exit-code> 1 => 0 </exit-code>
 endmodule
 
 module DRIVER-BASE-SYNTAX

--- a/prover/drivers/kore-driver.md
+++ b/prover/drivers/kore-driver.md
@@ -67,18 +67,18 @@ in the subgoal and the claim of the named goal remains intact.
            ...
        </k>
 
-  rule <k> claim NAME : PATTERN
-           strategy STRAT
-        => .K
-           ...
-       </k>
-       <goals>
+  rule <goals>
+         <k> claim NAME : PATTERN
+             strategy STRAT
+          => .K
+             ...
+         </k>
          ( .Bag =>
            <goal>
              <id> NAME </id>
              <active> true:Bool </active>
              <parent> .K </parent>
-             <claim> PATTERN </claim>
+             <k> PATTERN </k>
              <strategy> subgoal(PATTERN, STRAT) </strategy>
              <expected> success </expected>
              <local-context> .Bag </local-context>

--- a/prover/drivers/kore-driver.md
+++ b/prover/drivers/kore-driver.md
@@ -66,34 +66,11 @@ in the subgoal and the claim of the named goal remains intact.
         => claim getFreshClaimName() : PATTERN strategy STRAT
            ...
        </k>
-
-  rule <goals>
-         <k> claim NAME : PATTERN
-             strategy STRAT
-          => .K
-             ...
-         </k>
-         ( .Bag =>
-           <goal>
-             <id> NAME </id>
-             <active> true:Bool </active>
-             <parent> .K </parent>
-             <k> PATTERN </k>
-             <strategy> subgoal(PATTERN, STRAT) </strategy>
-             <expected> success </expected>
-             <local-context> .Bag </local-context>
-             <trace> .K </trace>
-           </goal>
-         )
-         ...
-       </goals>
-```
-
-```k
-  rule <id> _:ClaimName </id>
-       <expected> S:TerminalStrategy </expected>
-       <strategy> S </strategy>
-       <exit-code> 1 => 0 </exit-code>
+  rule <k> claim NAME : PATTERN
+           strategy STRAT
+        => subgoal(NAME, PATTERN, subgoal(PATTERN, STRAT))
+           ...
+       </k>
 ```
 
 ```k

--- a/prover/drivers/smt-driver.md
+++ b/prover/drivers/smt-driver.md
@@ -318,24 +318,21 @@ module DRIVER-SMT
   rule #containsSpatialPatterns(.Patterns, _) => false
   rule #containsSpatialPatterns((P, Ps), S) => #containsSpatial(P, S) orBool #containsSpatialPatterns(Ps, S)
 
+  syntax KItem ::= "expect" TerminalStrategy
+  rule <strategy> S ~> expect S => .K ... </strategy>
+  
   rule <goals>
          <k> #goal( goal: (\exists{Vs} \and(Ps)) #as PATTERN, strategy: STRAT, expected: EXPECTED)
           ~> (check-sat)
           => #goal( goal: PATTERN, strategy: STRAT, expected: EXPECTED)
              ...
          </k>
-         ( .Bag =>
-           <goal>
-             <id> !N:ClaimName </id>
-             <active> true:Bool </active>
-             <parent> .K </parent>
-             <k> \implies(\and(#filterPositive(Ps)), \and(\or(#filterNegative(Ps)))) </k>
-             <strategy> STRAT </strategy>
-             <expected> EXPECTED </expected>
-             <local-context> .Bag </local-context>
-             <trace> .K </trace>
-           </goal>
-         )
+         <strategy> .K
+                 => subgoal(\implies(\and(#filterPositive(Ps)), \and(\or(#filterNegative(Ps))))
+                           , STRAT
+                           )
+                 ~> expect EXPECTED
+         </strategy>
          ...
        </goals>
    requires notBool PATTERN ==K  \exists { .Patterns } \and ( .Patterns )

--- a/prover/drivers/smt-driver.md
+++ b/prover/drivers/smt-driver.md
@@ -318,18 +318,18 @@ module DRIVER-SMT
   rule #containsSpatialPatterns(.Patterns, _) => false
   rule #containsSpatialPatterns((P, Ps), S) => #containsSpatial(P, S) orBool #containsSpatialPatterns(Ps, S)
 
-  rule <k> #goal( goal: (\exists{Vs} \and(Ps)) #as PATTERN, strategy: STRAT, expected: EXPECTED)
-        ~> (check-sat)
-        => #goal( goal: PATTERN, strategy: STRAT, expected: EXPECTED)
-           ...
-       </k>
-       <goals>
+  rule <goals>
+         <k> #goal( goal: (\exists{Vs} \and(Ps)) #as PATTERN, strategy: STRAT, expected: EXPECTED)
+          ~> (check-sat)
+          => #goal( goal: PATTERN, strategy: STRAT, expected: EXPECTED)
+             ...
+         </k>
          ( .Bag =>
            <goal>
              <id> !N:ClaimName </id>
              <active> true:Bool </active>
              <parent> .K </parent>
-             <claim> \implies(\and(#filterPositive(Ps)), \and(\or(#filterNegative(Ps)))) </claim>
+             <k> \implies(\and(#filterPositive(Ps)), \and(\or(#filterNegative(Ps)))) </k>
              <strategy> STRAT </strategy>
              <expected> EXPECTED </expected>
              <local-context> .Bag </local-context>

--- a/prover/lib/testlists.py
+++ b/prover/lib/testlists.py
@@ -86,6 +86,7 @@ test_lists = [ ('unfold-mut-recs . ',    3,  3,  '5m', read_list('t/test-lists/p
              , ('unfold-mut-recs . ',   10, 16, '20m', ['t/SL-COMP18/bench/qf_shid_entl/ls_nonrec_entail_ls_11.sb.smt2'])
              , ('unfold-mut-recs . ',    6, 16, '10m', ['t/SL-COMP18/bench/qf_shid_entl/ls_nonrec_entail_ls_12.sb.smt2'])
              , ('unfold-mut-recs . ',   12, 18, '75m', ['t/SL-COMP18/bench/qf_shid_entl/ls_nonrec_entail_ls_13.sb.smt2'])
+             , ('unfold-mut-recs . ',   14, 21,'220m', ['t/SL-COMP18/bench/qf_shid_entl/ls_nonrec_entail_ls_14.sb.smt2'])
              ## these 3 tests should go  through with this strategy, but they will need a very high
              ## time bound (>60m)
              # , ('unfold-mut-recs . ',   14, 20, '60m', ['t/SL-COMP18/bench/qf_shid_entl/ls_nonrec_entail_ls_14.sb.smt2'])

--- a/prover/strategies/apply-equation.md
+++ b/prover/strategies/apply-equation.md
@@ -119,7 +119,7 @@ module STRATEGY-APPLY-EQUATION
         )
         ...
       </strategy>
-      <claim> T </claim>
+      <k> T </k>
 
   syntax KItem ::= "#apply-equation3"
                    "(" "hypothesis:" Pattern
@@ -138,9 +138,9 @@ module STRATEGY-APPLY-EQUATION
          => instantiateAssumptions(Subst, P)
          ~> createSubgoalsWithStrategies(strats: Ss, result: noop)
        ...</strategy>
-       <claim>
+       <k>
          _ => cool(heated: Heated, term: substMap(R, Subst))
-       </claim>
+       </k>
 
   syntax KItem ::= "createSubgoalsWithStrategies"
                    "(" "strats:" Strategies

--- a/prover/strategies/apply.md
+++ b/prover/strategies/apply.md
@@ -37,7 +37,7 @@ module STRATEGY-APPLY
                Strat
              )
          ...</strategy>
-         <claim> G </claim>
+         <k> G </k>
 
 
   syntax KItem ::= #apply1(Pattern, MatchResult, Strategy)

--- a/prover/strategies/core.md
+++ b/prover/strategies/core.md
@@ -89,18 +89,16 @@ completed, its result is replaced in the parent goal and the subgoal is removed.
 ```k
   syntax Strategy ::= goalStrat(GoalId)
   rule <prover>
-         <goal> <id> PID </id>
-                <active> _ => true </active>
-                <strategy> goalStrat(ID) => RStrat ... </strategy>
-                ...
-         </goal>
          ( <goal> <id> ID </id>
-                  <active> true:Bool </active>
                   <parent> PID </parent>
                   <strategy> RStrat:TerminalStrategy </strategy>
                   ...
            </goal> => .Bag
          )
+         <goal> <id> PID </id>
+                <strategy> goalStrat(ID) => RStrat ... </strategy>
+                ...
+         </goal>
          ...
        </prover>
 ```
@@ -116,7 +114,6 @@ Proving a goal may involve proving other subgoals:
          ( .Bag =>
              <goal>
                <id> ID:Int </id>
-               <active> true </active>
                <parent> PARENT </parent>
                <strategy> SUBSTRAT </strategy>
                <k> SUBGOAL </k>
@@ -127,7 +124,6 @@ Proving a goal may involve proving other subgoals:
          )
          <goal>
            <id> PARENT </id>
-           <active> true => false </active>
            <strategy> subgoal(ID, SUBGOAL, SUBSTRAT) => goalStrat(ID:Int) ... </strategy>
            <local-context> LC::Bag </local-context>
            <trace> TRACE </trace>

--- a/prover/strategies/core.md
+++ b/prover/strategies/core.md
@@ -116,7 +116,7 @@ Proving a goal may involve proving other subgoals:
                <active> true </active>
                <parent> PARENT </parent>
                <strategy> SUBSTRAT </strategy>
-               <claim> SUBGOAL </claim>
+               <k> SUBGOAL </k>
                <local-context> LC </local-context>
                <trace> TRACE </trace>
                ...
@@ -151,7 +151,7 @@ all succeed, it succeeds:
   rule <prover>
          <goal>
            <strategy> ((S1 & S2) => subgoal(GOAL, S1) ~> #hole & S2) </strategy>
-           <claim> GOAL:Pattern </claim>
+           <k> GOAL:Pattern </k>
            ...
          </goal>
          ...
@@ -177,7 +177,7 @@ approach succeeds:
   rule <prover>
          <goal>
            <strategy> ((S1 | S2) => subgoal(GOAL, S1) ~> #hole | S2 ) </strategy>
-           <claim> GOAL:Pattern </claim>
+           <k> GOAL:Pattern </k>
            ...
          </goal>
          ...
@@ -199,7 +199,7 @@ Internal strategy used to implement `or-split` and `and-split`.
 
 ```k
   syntax Strategy ::= "replace-goal" "(" Pattern ")"
-  rule <claim> _ => NEWGOAL </claim>
+  rule <k> _ => NEWGOAL </k>
        <strategy> replace-goal(NEWGOAL) => noop ... </strategy>
 ```
 
@@ -212,7 +212,7 @@ Internal strategy used to implement `or-split` and `and-split`.
 ```
 
 ```k
-  rule <claim> \or(GOALS) </claim>
+  rule <k> \or(GOALS) </k>
        <strategy> or-split => #orSplit(GOALS) ... </strategy>
 
   syntax Strategy ::= "#orSplit" "(" Patterns ")" [function]
@@ -230,16 +230,16 @@ Internal strategy used to implement `or-split` and `and-split`.
 ```
 
 ```k
-  rule <claim> \implies(LHS, \exists { Vs } \and(\or(RHSs), REST)) </claim>
+  rule <k> \implies(LHS, \exists { Vs } \and(\or(RHSs), REST)) </k>
        <strategy> or-split-rhs => #orSplitImplication(LHS, Vs, RHSs, REST) ... </strategy>
 
-  rule <claim> \implies(LHS, \exists { Vs } \and(RHSs, REST)) </claim>
+  rule <k> \implies(LHS, \exists { Vs } \and(RHSs, REST)) </k>
        <strategy> or-split-rhs => noop ... </strategy>
     requires notBool isDisjunction(RHSs)
-  rule <claim> \implies(LHS, \exists { Vs } \and(.Patterns)) </claim>
+  rule <k> \implies(LHS, \exists { Vs } \and(.Patterns)) </k>
        <strategy> or-split-rhs => noop ... </strategy>
 
-  rule <claim> \implies(LHS, \exists { Vs } \and(.Patterns)) </claim>
+  rule <k> \implies(LHS, \exists { Vs } \and(.Patterns)) </k>
        <strategy> or-split-rhs => noop ... </strategy>
 
   syntax Strategy ::= "#orSplitImplication" "(" Pattern "," Patterns "," Patterns "," Patterns ")" [function]
@@ -257,7 +257,7 @@ Internal strategy used to implement `or-split` and `and-split`.
 ```
 
 ```k
-  rule <claim> \and(GOALS) </claim>
+  rule <k> \and(GOALS) </k>
        <strategy> and-split => #andSplit(GOALS) ... </strategy>
 
   syntax Strategy ::= "#andSplit" "(" Patterns ")" [function]

--- a/prover/strategies/core.md
+++ b/prover/strategies/core.md
@@ -109,10 +109,13 @@ Proving a goal may involve proving other subgoals:
 
 ```k
   syntax Strategy ::= "subgoal" "(" Pattern "," Strategy ")"
+  rule <strategy> subgoal(GOAL, STRAT) => subgoal(!ID:Int, GOAL, STRAT) ... </strategy>
+
+  syntax Strategy ::= "subgoal" "(" GoalId "," Pattern "," Strategy ")"
   rule <prover>
          ( .Bag =>
              <goal>
-               <id> !ID:Int </id>
+               <id> ID:Int </id>
                <active> true </active>
                <parent> PARENT </parent>
                <strategy> SUBSTRAT </strategy>
@@ -125,7 +128,7 @@ Proving a goal may involve proving other subgoals:
          <goal>
            <id> PARENT </id>
            <active> true => false </active>
-           <strategy> subgoal(SUBGOAL, SUBSTRAT) => goalStrat(!ID:Int) ... </strategy>
+           <strategy> subgoal(ID, SUBGOAL, SUBSTRAT) => goalStrat(ID:Int) ... </strategy>
            <local-context> LC::Bag </local-context>
            <trace> TRACE </trace>
            ...

--- a/prover/strategies/inst-exists.md
+++ b/prover/strategies/inst-exists.md
@@ -16,9 +16,9 @@ module STRATEGY-INST-EXISTS
          inst-exists(V, T, Strat)
          => subgoal(\functionalPattern(T), Strat) & noop
        ...</strategy>
-       <claim>
+       <k>
          P => instExists(P, V, T)
-       </claim>
+       </k>
 
   syntax Pattern ::= instExists(Pattern, Variable, Pattern) [function]
 

--- a/prover/strategies/intros.md
+++ b/prover/strategies/intros.md
@@ -11,7 +11,7 @@ module STRATEGY-INTROS
   imports KORE-HELPERS
 
   rule <strategy> intros Name => noop ...</strategy>
-       <claim> \implies(H, G) => G </claim>
+       <k> \implies(H, G) => G </k>
        <local-context> (.Bag =>
          <local-decl> axiom Name : H </local-decl>
          ) ...

--- a/prover/strategies/knaster-tarski.md
+++ b/prover/strategies/knaster-tarski.md
@@ -50,7 +50,7 @@ for guessing an instantiation of the inductive hypothesis.
 
 ```k
   rule <strategy> kt => kt # .KTFilter ... </strategy>
-  rule <claim> \implies(\and(LHS), RHS) </claim>
+  rule <k> \implies(\and(LHS), RHS) </k>
        <strategy> kt # FILTER
                => getKTUnfoldables(LHS) ~> kt # FILTER
                   ...
@@ -89,7 +89,7 @@ for guessing an instantiation of the inductive hypothesis.
 
 ```k
   rule <strategy> kt-unf => kt-unf # .KTFilter ... </strategy>
-  rule <claim> \implies(\and(LHS), RHS) </claim>
+  rule <k> \implies(\and(LHS), RHS) </k>
        <strategy> kt-unf # FILTER
                => getKTUnfoldables(LHS) ~> kt-unf # FILTER
                   ...
@@ -139,9 +139,9 @@ for guessing an instantiation of the inductive hypothesis.
 
 ```k
   syntax Strategy ::= "kt-wrap" "(" Pattern ")"
-  rule <claim> \implies(\and(LHS:Patterns), RHS)
+  rule <k> \implies(\and(LHS:Patterns), RHS)
         => \implies(LRP, implicationContext(\and(#hole, (LHS -Patterns LRP)), RHS))
-       </claim>
+       </k>
        <strategy> kt-wrap(LRP) => noop ... </strategy>
        <trace> .K => kt-wrap(LRP)  ... </trace>
     requires LRP in LHS
@@ -151,13 +151,13 @@ for guessing an instantiation of the inductive hypothesis.
 ## kt-wrap (SL)
 
 ```k
-  rule <claim> \implies(\and(sep(LSPATIAL), LCONSTRAINT:Patterns), RHS)
+  rule <k> \implies(\and(sep(LSPATIAL), LCONSTRAINT:Patterns), RHS)
             => \implies(LRP, implicationContext(\and( sep(#hole, (LSPATIAL -Patterns LRP))
                                                     , LCONSTRAINT
                                                     )
                                                , RHS)
                        )
-       </claim>
+       </k>
        <strategy> kt-wrap(LRP) => noop ... </strategy>
        <trace> .K => kt-wrap(LRP)  ... </trace>
     requires LRP in LSPATIAL
@@ -170,12 +170,12 @@ for guessing an instantiation of the inductive hypothesis.
 
 ```k
   syntax Strategy ::= "kt-forall-intro"
-  rule <claim> \implies(LHS, RHS) #as GOAL
+  rule <k> \implies(LHS, RHS) #as GOAL
         => \implies( LHS
                    , \forall { getUniversalVariables(GOAL) -Patterns getFreeVariables(LHS, .Patterns) }
                              RHS
                    )
-       </claim>
+       </k>
        <strategy> kt-forall-intro => noop ... </strategy>
 ```
 
@@ -185,7 +185,7 @@ for guessing an instantiation of the inductive hypothesis.
 
 ```k
   syntax Strategy ::= "kt-forall-elim"
-  rule <claim> \implies(LHS, \forall { Vs } RHS) => \implies(LHS, RHS) </claim>
+  rule <k> \implies(LHS, \forall { Vs } RHS) => \implies(LHS, RHS) </k>
        <strategy> kt-forall-elim => noop ... </strategy>
     requires getFreeVariables(LHS) -Patterns Vs ==K getFreeVariables(LHS)
 ```
@@ -195,16 +195,16 @@ for guessing an instantiation of the inductive hypothesis.
 
 ```k
   syntax Strategy ::= "kt-unfold"
-  rule <claim> \implies( LRP(ARGS) #as LHS
+  rule <k> \implies( LRP(ARGS) #as LHS
                   => substituteBRPs(unfold(LHS), LRP, ARGS, RHS)
                    , RHS
                    )
-       </claim>
+       </k>
        <strategy> kt-unfold => noop ... </strategy>
     requires removeDuplicates(ARGS) ==K ARGS
      andBool isUnfoldable(LRP)
-  rule <claim> \implies(LRP(ARGS), RHS)
-       </claim>
+  rule <k> \implies(LRP(ARGS), RHS)
+       </k>
        <strategy> kt-unfold => fail ... </strategy>
     requires removeDuplicates(ARGS) =/=K ARGS
      andBool isUnfoldable(LRP)
@@ -245,9 +245,9 @@ for guessing an instantiation of the inductive hypothesis.
 
 ```k
   syntax Strategy ::= "kt-unwrap"
-  rule <claim> \implies(LHS, \forall { UNIV } implicationContext(CTX, RHS))
+  rule <k> \implies(LHS, \forall { UNIV } implicationContext(CTX, RHS))
         => \implies(subst(CTX, #hole, LHS), RHS)
-       </claim>
+       </k>
        <strategy> kt-unwrap => noop ... </strategy>
 ```
 
@@ -261,11 +261,11 @@ for guessing an instantiation of the inductive hypothesis.
 If there are no implication contexts to collapse, we are done:
 
 ```k
-  rule <claim> GOAL </claim>
+  rule <k> GOAL </k>
        <strategy> kt-collapse => noop ... </strategy>
     requires notBool(hasImplicationContext(GOAL))
 
-  rule <claim> GOAL </claim>
+  rule <k> GOAL </k>
        <strategy> imp-ctx-unfold => noop ... </strategy>
     requires notBool(hasImplicationContext(GOAL))
 ```
@@ -276,9 +276,9 @@ Bring terms containing the implication context to the front:
 
 ```k
   // FOL case
-  rule <claim> \implies(\and(P, Ps) #as LHS, RHS)
+  rule <k> \implies(\and(P, Ps) #as LHS, RHS)
             => \implies(\and(Ps ++Patterns P), RHS)
-       </claim>
+       </k>
        <strategy> kt-collapse ... </strategy>
     requires notBool hasImplicationContext(P)
      andBool hasImplicationContext(LHS)
@@ -286,16 +286,16 @@ Bring terms containing the implication context to the front:
 
 ```k
   // SL case
-  rule <claim> \implies(\and((sep(S, Ss) #as LSPATIAL), Ps), RHS)
+  rule <k> \implies(\and((sep(S, Ss) #as LSPATIAL), Ps), RHS)
             => \implies(\and(sep(Ss ++Patterns S), Ps), RHS)
-       </claim>
+       </k>
        <strategy> kt-collapse ... </strategy>
     requires notBool hasImplicationContext(S)
      andBool hasImplicationContext(LSPATIAL)
 
-  rule <claim> \implies(\and((sep(S, Ss) #as LSPATIAL), Ps), RHS)
+  rule <k> \implies(\and((sep(S, Ss) #as LSPATIAL), Ps), RHS)
             => \implies(\and(sep(Ss ++Patterns S), Ps), RHS)
-       </claim>
+       </k>
        <strategy> imp-ctx-unfold ... </strategy>
     requires notBool hasImplicationContext(S)
      andBool hasImplicationContext(LSPATIAL)
@@ -308,22 +308,22 @@ Move #holes to the front
 // be better?
 
 ```k
-  rule <claim> \implies(\and(\forall { _ }
+  rule <k> \implies(\and(\forall { _ }
                          implicationContext( \and(P, Ps)
                                           => \and(Ps ++Patterns P)
                                            , _)
                         , _), _)
-       </claim>
+       </k>
        <strategy> kt-collapse ... </strategy>
     requires P =/=K #hole:Pattern
      andBool #hole in Ps
 
-  rule <claim> \implies(\and(sep(\forall { _ }
+  rule <k> \implies(\and(sep(\forall { _ }
                          implicationContext( \and(P, Ps)
                                           => \and(Ps ++Patterns P)
                                            , _)
                         ,_ ), _), _)
-       </claim>
+       </k>
        <strategy> kt-collapse ... </strategy>
     requires P =/=K #hole:Pattern
      andBool #hole in Ps
@@ -335,7 +335,7 @@ In the FOL case, we create an implication, and dispatch that to the smt
 solver using `kt-solve-implications`
 
 ```k
-  rule <claim> \implies(\and( \forall { UNIVs }
+  rule <k> \implies(\and( \forall { UNIVs }
                               ( implicationContext( \and(#hole, CTXLHS:Patterns)
                                                   , CTXRHS:Pattern
                                                   )
@@ -345,7 +345,7 @@ solver using `kt-solve-implications`
                         )
                    , RHS:Pattern
                    )
-       </claim>
+       </k>
        <strategy> kt-collapse ... </strategy>
 ```
 
@@ -359,7 +359,7 @@ Next, duplicate constraints are removed using the ad-hoc rule below until the im
 context has no constraints.
 
 ```k
-  rule <claim> \implies(\and( sep ( \forall { UNIVs }
+  rule <k> \implies(\and( sep ( \forall { UNIVs }
                                     implicationContext( \and(sep(#hole, CTXLHS:Patterns), CTXLCONSTRAINTS) , _)
                                   , LSPATIAL
                                   )
@@ -367,7 +367,7 @@ context has no constraints.
                             )
                        , RHS:Pattern
                        )
-       </claim>
+       </k>
        <strategy> kt-collapse
                => with-each-match( #match(terms: LSPATIAL, pattern: CTXLHS, variables: UNIVs)
                                  , kt-collapse
@@ -378,7 +378,7 @@ context has no constraints.
 ```
 
 ```k
-  rule <claim> \implies(\and( ( sep ( \forall { UNIVs => .Patterns }
+  rule <k> \implies(\and( ( sep ( \forall { UNIVs => .Patterns }
                                       ( implicationContext( \and(sep(_), CTXLCONSTRAINTS), CTXRHS ) #as CTX
                                      => substMap(CTX, SUBST)
                                       )
@@ -389,7 +389,7 @@ context has no constraints.
                             )
                        , RHS:Pattern
                        )
-       </claim>
+       </k>
        <strategy> ( #matchResult(subst: SUBST, rest: REST) ~> kt-collapse )
                => kt-collapse
                   ...
@@ -397,7 +397,7 @@ context has no constraints.
      requires UNIVs =/=K .Patterns
       andBool UNIVs -Patterns fst(unzip(SUBST)) ==K .Patterns
 
-  rule <claim> \implies(\and( ( sep ( \forall { UNIVs => .Patterns }
+  rule <k> \implies(\and( ( sep ( \forall { UNIVs => .Patterns }
                                       ( implicationContext( \and(sep(_), CTXLCONSTRAINTS), CTXRHS ) #as CTX
                                       )
                                     , LSPATIAL
@@ -407,7 +407,7 @@ context has no constraints.
                             )
                        , RHS:Pattern
                        )
-       </claim>
+       </k>
        <strategy> ( #matchResult(subst: SUBST, rest: REST) ~> kt-collapse )
                => fail
                   ...
@@ -419,7 +419,7 @@ context has no constraints.
 Finally, we use matching on the no universal quantifiers case to collapse the context.
 
 ```k
-  rule <claim> \implies(\and( sep ( \forall { .Patterns }
+  rule <k> \implies(\and( sep ( \forall { .Patterns }
                                     implicationContext( \and(sep(#hole, CTXLHS:Patterns)) , _)
                                   , LSPATIAL
                                   )
@@ -427,7 +427,7 @@ Finally, we use matching on the no universal quantifiers case to collapse the co
                             )
                        , RHS:Pattern
                        )
-       </claim>
+       </k>
        <strategy> kt-collapse
                => with-each-match( #match(terms: LSPATIAL, pattern: CTXLHS, variables: .Patterns)
                                  , kt-collapse
@@ -435,7 +435,7 @@ Finally, we use matching on the no universal quantifiers case to collapse the co
                   ...
        </strategy>
 
-  rule <claim> \implies( \and( ( sep ( \forall { .Patterns }
+  rule <k> \implies( \and( ( sep ( \forall { .Patterns }
                                        implicationContext( \and(sep(_)) , CTXRHS)
                                      , LSPATIAL
                                      )
@@ -445,7 +445,7 @@ Finally, we use matching on the no universal quantifiers case to collapse the co
                              )
                        , RHS:Pattern
                        )
-       </claim>
+       </k>
        <strategy> ( #matchResult(subst: SUBST, rest: REST) ~> kt-collapse )
                => kt-collapse
                   ...
@@ -455,7 +455,7 @@ Finally, we use matching on the no universal quantifiers case to collapse the co
 TODO: This is pretty adhoc: Remove constraints in the context that are already in the LHS
 
 ```k
-  rule <claim> \implies(\and( sep ( \forall { .Patterns }
+  rule <k> \implies(\and( sep ( \forall { .Patterns }
                                     implicationContext( \and( sep(_)
                                                             , ( CTXCONSTRAINT, CTXCONSTRAINTs
                                                              => CTXCONSTRAINTs
@@ -467,12 +467,12 @@ TODO: This is pretty adhoc: Remove constraints in the context that are already i
                             )
                        , RHS:Pattern
                        )
-       </claim>
+       </k>
        <strategy> kt-collapse ... </strategy>
     requires isPredicatePattern(CTXCONSTRAINT)
      andBool CTXCONSTRAINT in LHS
 
-  rule <claim> \implies(\and( sep ( \forall { .Patterns }
+  rule <k> \implies(\and( sep ( \forall { .Patterns }
                                     implicationContext( \and( sep(_)
                                                             , ( CTXCONSTRAINT, CTXCONSTRAINTs )
                                                             ) , _)
@@ -482,7 +482,7 @@ TODO: This is pretty adhoc: Remove constraints in the context that are already i
                             )
                        , RHS:Pattern
                        )
-       </claim>
+       </k>
        <strategy> kt-collapse => fail ... </strategy>
     requires isPredicatePattern(CTXCONSTRAINT)
      andBool notBool (CTXCONSTRAINT in LHS)
@@ -495,7 +495,7 @@ TODO: This is pretty adhoc: Remove constraints in the context that are already i
 ```
 
 ```k
-  rule <claim> \implies(\and( sep ( \forall { UNIVs }
+  rule <k> \implies(\and( sep ( \forall { UNIVs }
                                     implicationContext( \and( sep( #hole
                                                                  , CTXLHS:Patterns
                                                                  )
@@ -509,11 +509,11 @@ TODO: This is pretty adhoc: Remove constraints in the context that are already i
                             )
                        , RHS:Pattern
                        )
-       </claim>
+       </k>
        <strategy> imp-ctx-unfold => right-unfold-eachRRP(getUnfoldables(CTXLHS)) ... </strategy>
      requires UNIVs =/=K .Patterns
 
-  rule <claim> \implies(\and( sep ( \forall { .Patterns }
+  rule <k> \implies(\and( sep ( \forall { .Patterns }
                                     implicationContext( \and(sep(#hole, CTXLHS:Patterns)) , _)
                                   , LSPATIAL
                                   )
@@ -521,7 +521,7 @@ TODO: This is pretty adhoc: Remove constraints in the context that are already i
                             )
                        , RHS:Pattern
                        )
-       </claim>
+       </k>
        <strategy> imp-ctx-unfold => right-unfold-eachRRP(getUnfoldables(CTXLHS)) ... </strategy>
 ```
 
@@ -542,22 +542,22 @@ TODO: This is pretty adhoc: Remove constraints in the context that are already i
     => filterVariablesBySort(Vs, S) [owise]
 
   // TODO: Move to "normalize" strategy
-  rule <claim> \implies(\and(\and(Ps1), Ps2), RHS)
+  rule <k> \implies(\and(\and(Ps1), Ps2), RHS)
         => \implies(\and(Ps1 ++Patterns Ps2), RHS)
-       </claim>
+       </k>
        <strategy> kt-collapse ... </strategy>
-  rule <claim> \implies(\and(_, ( \and(Ps1), Ps2
+  rule <k> \implies(\and(_, ( \and(Ps1), Ps2
                            => Ps1 ++Patterns Ps2))
                    , RHS)
-       </claim>
+       </k>
        <strategy> kt-collapse ... </strategy>
 
-  rule <claim> \implies(\and( _
+  rule <k> \implies(\and( _
                         , (\exists { _ } P => P)
                         , Ps)
                    , _
                    )
-       </claim>
+       </k>
        <strategy> kt-collapse ... </strategy>
 ```
 
@@ -566,11 +566,11 @@ TODO: This is pretty adhoc: Remove constraints in the context that are already i
 >      (alpha -> beta) /\ gamma -> psi
 
 ```k
-  rule <claim> \implies( \and(\forall { .Patterns } \implies(LHS, RHS), REST:Patterns)
+  rule <k> \implies( \and(\forall { .Patterns } \implies(LHS, RHS), REST:Patterns)
                   => \and(REST)
                    , _
                    )
-       </claim>
+       </k>
        <strategy> kt-solve-implications( STRAT)
                => ( kt-solve-implication( subgoal(\implies(\and(removeImplications(REST)), LHS), STRAT)
                                         , \and(LHS, RHS)
@@ -587,18 +587,18 @@ TODO: This is pretty adhoc: Remove constraints in the context that are already i
     requires matchesImplication(P)
   rule removeImplications(.Patterns) => .Patterns
 
-  rule <claim> \implies( \and(P:Pattern, REST:Patterns)
+  rule <k> \implies( \and(P:Pattern, REST:Patterns)
                   => \and(REST ++Patterns P)
                    , _
                    )
-       </claim>
+       </k>
        <strategy> kt-solve-implications(_)
                   ...
        </strategy>
     requires hasImplication(REST)
      andBool notBool matchesImplication(P)
 
-  rule <claim> \implies(\and(LHS), _) </claim>
+  rule <k> \implies(\and(LHS), _) </k>
        <strategy> kt-solve-implications(STRAT) => noop ... </strategy>
      requires notBool hasImplication(LHS)
 
@@ -628,14 +628,14 @@ If the subgoal in the first argument succeeds add the second argument to the LHS
        </strategy>
   rule <strategy> kt-solve-implication(fail, RHS) => noop ... </strategy>
   rule <strategy> kt-solve-implication(success, CONC) => noop ... </strategy>
-       <claim> \implies(\and(LHS), RHS)
+       <k> \implies(\and(LHS), RHS)
         => \implies(\and(CONC, LHS), RHS)
-       </claim>
+       </k>
 ```
 
 ```k
   syntax Strategy ::= "instantiate-universals-with-ground-terms" "(" Patterns /* universals */ "," Patterns /* ground terms */ ")"
-  rule <claim> \implies(\and(LHS), RHS) #as GOAL </claim>
+  rule <k> \implies(\and(LHS), RHS) #as GOAL </k>
        <strategy> instantiate-universals-with-ground-terms
                => instantiate-universals-with-ground-terms(getForalls(LHS), removeDuplicates(getGroundTerms(GOAL)))
                   ...
@@ -648,14 +648,14 @@ If the subgoal in the first argument succeeds add the second argument to the LHS
                   ...
        </strategy>
 
-  rule <claim> \implies(\and(LHS => P, LHS), RHS) </claim> 
+  rule <k> \implies(\and(LHS => P, LHS), RHS) </k> 
        <strategy> instantiate-universals-with-ground-terms( (\forall { .Patterns } P:Pattern , REST_FORALLs) => REST_FORALLs 
                                  , _
                                  )
                   ...
        </strategy>
     requires notBool P in LHS
-  rule <claim> \implies(\and(LHS), RHS) </claim> 
+  rule <k> \implies(\and(LHS), RHS) </k> 
        <strategy> instantiate-universals-with-ground-terms( (\forall { .Patterns } P:Pattern , REST_FORALLs) => REST_FORALLs 
                                  , _
                                  )

--- a/prover/strategies/matching.md
+++ b/prover/strategies/matching.md
@@ -367,7 +367,7 @@ The `with-each-match` strategy
 Instantiate existentials using matching on the spatial part of goals:
 
 ```k
-  rule <claim> \implies(\and(sep(LSPATIAL), LHS) , \exists { Vs } \and(sep(RSPATIAL), RHS)) </claim>
+  rule <k> \implies(\and(sep(LSPATIAL), LHS) , \exists { Vs } \and(sep(RSPATIAL), RHS)) </k>
        <strategy> match
                => with-each-match(#match( terms: LSPATIAL
                                         , pattern: RSPATIAL
@@ -379,21 +379,21 @@ Instantiate existentials using matching on the spatial part of goals:
        </strategy>
     requires isSpatialPattern(sep(LSPATIAL))
      andBool isSpatialPattern(sep(RSPATIAL))
-  rule <claim> \implies( \and( LSPATIAL, LHS)
+  rule <k> \implies( \and( LSPATIAL, LHS)
                        ,  \exists { Vs } \and( RHS )
                        => \exists { Vs -Patterns fst(unzip(SUBST)) } substMap(\and(RHS), SUBST)
                        )
-       </claim>
+       </k>
        <strategy> ( #matchResult(subst: SUBST, rest: .Patterns) ~> match )
                => noop
                   ...
        </strategy>
 
-  rule <claim> \implies(LHS, \exists { Vs } \and(RSPATIAL, RHS)) </claim>
+  rule <k> \implies(LHS, \exists { Vs } \and(RSPATIAL, RHS)) </k>
        <strategy> match => fail ... </strategy>
     requires isPredicatePattern(LHS)
      andBool isSpatialPattern(RSPATIAL)
-  rule <claim> \implies(\and(LSPATIAL, LHS), \exists { Vs } RHS) </claim>
+  rule <k> \implies(\and(LSPATIAL, LHS), \exists { Vs } RHS) </k>
        <strategy> match => fail ... </strategy>
     requires isPredicatePattern(RHS)
      andBool isSpatialPattern(LSPATIAL)
@@ -407,19 +407,19 @@ Instantiate existentials using matching on the spatial part of goals:
 
 ```k
   syntax Strategy ::= "match-pto" "(" Patterns ")"
-  rule <claim> \implies( \and(sep(LSPATIAL), LHS)
+  rule <k> \implies( \and(sep(LSPATIAL), LHS)
                        , \exists { Vs } \and(sep(RSPATIAL), RHS)
                        )
-       </claim>
+       </k>
        <strategy> match-pto => match-pto(getPartiallyInstantiatedPtos(RSPATIAL, Vs)) ... </strategy>
   rule <strategy> match-pto(.Patterns)
                => noop
                   ...
        </strategy>
 
-  rule <claim> \implies( \and(sep(LSPATIAL), LHS:Patterns)
+  rule <k> \implies( \and(sep(LSPATIAL), LHS:Patterns)
                        , \exists { Vs } \and(sep(RSPATIAL), RHS:Patterns))
-       </claim>
+       </k>
        <strategy> match-pto(P, Ps:Patterns)
                => with-each-match(
                     #match( terms: LSPATIAL:Patterns
@@ -432,13 +432,13 @@ Instantiate existentials using matching on the spatial part of goals:
                 . match-pto(Ps:Patterns)
                   ...
        </strategy>
-  rule <claim> \implies( _
+  rule <k> \implies( _
                        ,  (\exists { Vs } \and( RHS ))
                        => ( \exists { Vs -Patterns fst(unzip(SUBST)) }
                             substMap(\and(RHS), SUBST)
                           )
                        )
-       </claim>
+       </k>
        <strategy> ( #matchResult(subst: SUBST, rest: _) ~> match-pto )
                => noop
                   ...
@@ -491,7 +491,7 @@ Instantiate heap axioms:
 Instantiate the axiom: `\forall { L, D } (pto L D) -> L != nil
 
 ```k
-    rule <claim> \implies(\and((sep(LSPATIAL)), LCONSTRAINT), RHS) </claim>
+    rule <k> \implies(\and((sep(LSPATIAL)), LCONSTRAINT), RHS) </k>
          <strategy> instantiate-axiom(\forall { Vs }
                                       \implies( \and(sep(AXIOM_LSPATIAL))
                                               , AXIOM_RHS
@@ -507,10 +507,10 @@ Instantiate the axiom: `\forall { L, D } (pto L D) -> L != nil
          </strategy>
        requires isSpatialPattern(sep(AXIOM_LSPATIAL))
 
-    rule <claim> \implies(\and((sep(_) #as LSPATIAL), (LCONSTRAINT => substMap(AXIOM_RHS, SUBST), LCONSTRAINT))
+    rule <k> \implies(\and((sep(_) #as LSPATIAL), (LCONSTRAINT => substMap(AXIOM_RHS, SUBST), LCONSTRAINT))
                          , RHS
                          )
-         </claim>
+         </k>
          <strategy> ( #matchResult( subst: SUBST, rest: _ ) , MRs
                    ~> instantiate-axiom(\forall { Vs }
                                         \implies( _
@@ -525,40 +525,40 @@ Instantiate the axiom: `\forall { L, D } (pto L D) -> L != nil
 
     rule <strategy> (.MatchResults ~> instantiate-axiom(_)) => noop ... </strategy>
 
-    rule <claim> \implies(               \and(sep(LSPATIAL), LCONSTRAINT)
+    rule <k> \implies(               \and(sep(LSPATIAL), LCONSTRAINT)
                          , \exists{ Vs } \and(sep(RSPATIAL), RCONSTRAINT)
                          )
               => \implies(\and(LCONSTRAINT), \exists { Vs } \and(RCONSTRAINT))
-         </claim>
+         </k>
          <strategy> spatial-patterns-equal => noop ... </strategy>
       requires LSPATIAL -Patterns RSPATIAL ==K .Patterns
        andBool RSPATIAL -Patterns LSPATIAL ==K .Patterns
 
-    rule <claim> \implies(               \and(sep(LSPATIAL), _)
+    rule <k> \implies(               \and(sep(LSPATIAL), _)
                          , \exists{ Vs } \and(sep(RSPATIAL), _)
                          )
-         </claim>
+         </k>
          <strategy> spatial-patterns-equal => fail ... </strategy>
       requires LSPATIAL -Patterns RSPATIAL =/=K .Patterns
         orBool RSPATIAL -Patterns LSPATIAL =/=K .Patterns
 ```
 
 ```k
-    rule <claim> \implies( \and(sep( LSPATIAL ) , _ )
+    rule <k> \implies( \and(sep( LSPATIAL ) , _ )
                          , \exists {_}
                            \and(sep( RSPATIAL ) , _ )
                          )
-         </claim>
+         </k>
          <strategy> frame => frame(LSPATIAL intersect RSPATIAL) ... </strategy>
 ```
 
 ```k
     syntax Strategy ::= "frame" "(" Patterns ")"
-    rule <claim> \implies( LHS
+    rule <k> \implies( LHS
                          , \exists { .Patterns }
                            \and( sep(_),  RCONSTRAINTs )
                          )
-         </claim>
+         </k>
          <strategy> frame(pto(LOC, VAL), Ps)
                  => subgoal( \implies( LHS
                                      , \and(filterClausesInvolvingVariable(LOC, RCONSTRAINTs))
@@ -573,11 +573,11 @@ Instantiate the axiom: `\forall { L, D } (pto L D) -> L != nil
                     ...
          </strategy>
 
-    rule <claim> \implies( \and( sep(LSPATIAL => (LSPATIAL -Patterns P)) , LCONSTRAINTs )
+    rule <k> \implies( \and( sep(LSPATIAL => (LSPATIAL -Patterns P)) , LCONSTRAINTs )
                          , \exists { .Patterns }
                            \and( (sep(RSPATIAL => RSPATIAL -Patterns P)) , (RCONSTRAINTs => RCONSTRAINTs -Patterns filterClausesInvolvingVariable(LOC, RCONSTRAINTs)) )
                          )
-         </claim>
+         </k>
          <strategy> success
                  ~> frame((pto(LOC, VAL) #as P), .Patterns)
                  => .K
@@ -586,11 +586,11 @@ Instantiate the axiom: `\forall { L, D } (pto L D) -> L != nil
       requires P in LSPATIAL
        andBool P in RSPATIAL
 
-    rule <claim> \implies( \and( sep(LSPATIAL => (LSPATIAL -Patterns P)) , LCONSTRAINTs )
+    rule <k> \implies( \and( sep(LSPATIAL => (LSPATIAL -Patterns P)) , LCONSTRAINTs )
                          , \exists { .Patterns }
                            \and( (sep(RSPATIAL => RSPATIAL -Patterns P)) , RCONSTRAINTs )
                          )
-         </claim>
+         </k>
          <strategy> frame((S:Symbol(_) #as P), Ps)  => frame(Ps)
                     ...
          </strategy>
@@ -609,12 +609,12 @@ Instantiate the axiom: `\forall { L, D } (pto L D) -> L != nil
       => .Patterns
 
     syntax Strategy ::= "subsume-spatial"
-    rule <claim> \implies( \and( sep(LSPATIAL:Patterns) , LCONSTRAINTs:Patterns)
+    rule <k> \implies( \and( sep(LSPATIAL:Patterns) , LCONSTRAINTs:Patterns)
                         => \and(                 LCONSTRAINTs:Patterns)
                          , \exists { Vs:Patterns }
                            \and( RHS:Patterns )
                          )
-         </claim>
+         </k>
          <strategy> subsume-spatial => noop
                     ...
          </strategy>

--- a/prover/strategies/reflexivity.md
+++ b/prover/strategies/reflexivity.md
@@ -5,10 +5,10 @@ module STRATEGY-REFLEXIVITY
   imports STRATEGIES-EXPORTED-SYNTAX
 
   rule <strategy> reflexivity => success ...</strategy>
-       <claim> \equals(P, P) </claim>
+       <k> \equals(P, P) </k>
 
   rule <strategy> reflexivity => fail ...</strategy>
-       <claim> \equals(P, Q) </claim>
+       <k> \equals(P, Q) </k>
        requires P =/=K Q
 
 

--- a/prover/strategies/replace-evar-with-func-constant.md
+++ b/prover/strategies/replace-evar-with-func-constant.md
@@ -18,7 +18,7 @@ module STRATEGY-REPLACE-EVAR-WITH-FUNC-CONSTANT
          replace-evar-with-func-constant .Variables
          => #rewfc(PatternsToVariables(getFreeVariables(P, .Patterns)))
        ...</strategy>
-       <claim> P </claim>
+       <k> P </k>
 
   syntax Variables ::= PatternsToVariables(Patterns) [function]
   rule PatternsToVariables(.Patterns) => .Variables
@@ -42,12 +42,12 @@ module STRATEGY-REPLACE-EVAR-WITH-FUNC-CONSTANT
                                GId, VariableName2String(N)))
        ...</strategy>
        <id> GId </id>
-       <claim> P </claim>
+       <k> P </k>
        requires V in getFreeVariables(P, .Patterns)
 
   rule <strategy> #rewfc2(N{S}, Sym) => .K ...</strategy>
        <id> GId </id>
-       <claim> P => subst(P, N{S}, Sym(.Patterns)) </claim>
+       <k> P => subst(P, N{S}, Sym(.Patterns)) </k>
        <local-context> (.Bag =>
          <local-decl> symbol Sym(.Sorts) : S </local-decl>
          <local-decl>
@@ -58,7 +58,7 @@ module STRATEGY-REPLACE-EVAR-WITH-FUNC-CONSTANT
 
   rule <strategy> #rewfc1(V) => "No such free variable"
        ...</strategy>
-       <claim> P </claim>
+       <k> P </k>
        requires notBool (V in getFreeVariables(P, .Patterns))
 
 endmodule

--- a/prover/strategies/simplification.md
+++ b/prover/strategies/simplification.md
@@ -16,7 +16,7 @@ module STRATEGY-SIMPLIFICATION
 ```
 
 ```k
-  rule <claim> \implies(LHS => #lhsRemoveExistentials(LHS), RHS) </claim>
+  rule <k> \implies(LHS => #lhsRemoveExistentials(LHS), RHS) </k>
        <strategy> remove-lhs-existential => noop ... </strategy>
 
   syntax Pattern  ::= #lhsRemoveExistentials(Pattern)    [function]
@@ -57,26 +57,26 @@ Normalize:
 
 ```k
 
-  rule <claim> P::Pattern => \and(P) </claim>
+  rule <k> P::Pattern => \and(P) </k>
        <strategy> normalize ... </strategy>
        requires \and(...) :/=K P andBool \implies(...) :/=K P
 
-  rule <claim> \and(P) => \implies(\and(.Patterns), \and(P)) </claim>
+  rule <k> \and(P) => \implies(\and(.Patterns), \and(P)) </k>
        <strategy> normalize ... </strategy>
 
-  rule <claim> \implies(LHS, \and(RHS))
+  rule <k> \implies(LHS, \and(RHS))
         => \implies(LHS, \exists { .Patterns } \and(RHS))
-       </claim>
+       </k>
        <strategy> normalize ... </strategy>
 
-  rule <claim> \implies(\and(LHS), \exists { Es } \and(RHS))
+  rule <k> \implies(\and(LHS), \exists { Es } \and(RHS))
         => \implies( \and(#normalizePs(#flattenAnds(#lhsRemoveExistentialsPs(LHS))))
                    , \exists { Es } \and(#normalizePs(#flattenAnds(RHS)))
                    )
-       </claim>
+       </k>
        <strategy> normalize => noop ... </strategy>
 
-  rule <claim> \not(_) #as P => #normalize(P) </claim>
+  rule <k> \not(_) #as P => #normalize(P) </k>
        <strategy> normalize => noop ... </strategy>
 
   syntax Pattern ::= #normalize(Pattern) [function]
@@ -104,7 +104,7 @@ Normalize:
 LHS terms of the form S(T, Vs) become S(V, Vs) /\ V = T
 
 ```k
-  rule <claim> \implies(LHS => #purify(LHS), RHS) ... </claim>
+  rule <k> \implies(LHS => #purify(LHS), RHS) ... </k>
        <strategy> purify => noop ... </strategy>
 
   syntax Pattern ::= #purify(Pattern) [function]
@@ -148,7 +148,7 @@ obligation of the form R(T, Vs) => R(T', Vs') becomes
 R(V, Vs) => exists V', R(V', Vs') and V = V'
 
 ```k
-  rule <claim> \implies(LHS, RHS) </claim>
+  rule <k> \implies(LHS, RHS) </k>
        <strategy> abstract
                => #getNewVariables(LHS, .Patterns)
                ~> #getNewVariables(RHS, .Patterns)
@@ -156,13 +156,13 @@ R(V, Vs) => exists V', R(V', Vs') and V = V'
               ...
        </strategy>
 
-  rule <claim> \implies(LHS, \and(\or(RHS)))
+  rule <k> \implies(LHS, \and(\or(RHS)))
             => \implies( #abstract(LHS, VsLHS)
                        , \exists{ VsRHS } \and( #dnf(\or(\and(#createEqualities(VsLHS, VsRHS))))
                                                 , #abstract(RHS, VsRHS)
                                                 )
                        )
-       </claim>
+       </k>
        <strategy> (VsLHS:Patterns ~> VsRHS:Patterns ~> abstract) => noop ... </strategy>
 
   syntax Patterns ::= #getNewVariables(Pattern, Patterns) [function]
@@ -214,10 +214,10 @@ R(V, Vs) => exists V', R(V', Vs') and V = V'
 Bring predicate constraints to the top of a term.
 
 ```k
-  rule <claim> \implies(\and(Ps) => #flattenAnd(#liftConstraints(\and(Ps)))
+  rule <k> \implies(\and(Ps) => #flattenAnd(#liftConstraints(\and(Ps)))
                        , \exists { _ } (\and(Rs) => #flattenAnd(#liftConstraints(\and(Rs))))
                        )
-       </claim>
+       </k>
        <strategy> lift-constraints => noop ... </strategy>
 
   syntax Pattern ::= #liftConstraints(Pattern) [function]
@@ -268,7 +268,7 @@ Lift `\or`s on the left hand sides of implications
 ```
 
 ```k
-  rule <claim> \implies(\or(LHSs), RHS) => \and( #liftOr(LHSs, RHS)) </claim>
+  rule <k> \implies(\or(LHSs), RHS) => \and( #liftOr(LHSs, RHS)) </k>
        <strategy> lift-or => noop ... </strategy>
 
   syntax Patterns ::= "#liftOr" "(" Patterns "," Pattern ")" [function]
@@ -283,7 +283,7 @@ Lift `\or`s on the left hand sides of implications
 > (\forall .Patterns . phi(x, y)) -> psi(y)
 
 ```k
-  rule <claim> \implies(\forall { .Patterns } \and(LHS) => \and(LHS), RHS) </claim>
+  rule <k> \implies(\forall { .Patterns } \and(LHS) => \and(LHS), RHS) </k>
        <strategy> simplify ... </strategy>
 ```
 
@@ -292,7 +292,7 @@ Lift `\or`s on the left hand sides of implications
 > \exists X . phi(x, y) -> psi(y)
 
 ```k
-  rule <claim> \implies(\exists { _ } \and(LHS) => \and(LHS), RHS) </claim>
+  rule <k> \implies(\exists { _ } \and(LHS) => \and(LHS), RHS) </k>
        <strategy> simplify ... </strategy>
 ```
 
@@ -301,7 +301,7 @@ Lift `\or`s on the left hand sides of implications
 > LHS /\ phi -> RHS /\ phi
 
 ```k
-  rule <claim> \implies(\and(LHS), \exists { _ } \and(RHS => RHS -Patterns LHS)) </claim>
+  rule <k> \implies(\and(LHS), \exists { _ } \and(RHS => RHS -Patterns LHS)) </k>
        <strategy> simplify => noop ... </strategy>
 ```
 
@@ -314,18 +314,18 @@ Lift `\or`s on the left hand sides of implications
 ```
 
 ```k
-  rule <claim> \implies( \and(LHS) , \exists { EXIST } \and(RHS) ) #as GOAL </claim>
+  rule <k> \implies( \and(LHS) , \exists { EXIST } \and(RHS) ) #as GOAL </k>
        <strategy> (. => getAtomForcingInstantiation(RHS, getExistentialVariables(GOAL)))
                ~> instantiate-existentials
                   ...
        </strategy>
 
-  rule <claim> \implies( \and(LHS) , \exists { EXIST } \and(RHS) )
+  rule <k> \implies( \and(LHS) , \exists { EXIST } \and(RHS) )
             => \implies( \and(LHS ++Patterns INSTANTIATION)
                        , \exists { EXIST -Patterns getFreeVariables(INSTANTIATION) }
                          \and(RHS -Patterns INSTANTIATION)
                        )
-       </claim>
+       </k>
        <strategy> (INSTANTIATION => .) ~> instantiate-existentials ... </strategy>
      requires INSTANTIATION =/=K .Patterns
 
@@ -355,7 +355,7 @@ Lift `\or`s on the left hand sides of implications
 ```
 
 ```k
-  rule <claim> \implies(\and(LHS), _) </claim>
+  rule <k> \implies(\and(LHS), _) </k>
        <strategy> substitute-equals-for-equals
                => (makeEqualitySubstitution(LHS) ~> substitute-equals-for-equals)
                   ...
@@ -367,11 +367,11 @@ Lift `\or`s on the left hand sides of implications
        </strategy>
     requires SUBST ==K .Map
 
-  rule <claim> \implies( \and(LHS => removeTrivialEqualities(substPatternsMap(LHS, SUBST)))
+  rule <k> \implies( \and(LHS => removeTrivialEqualities(substPatternsMap(LHS, SUBST)))
                        , \exists { _ }
                          ( \and(RHS => removeTrivialEqualities(substPatternsMap(RHS, SUBST))) )
                        )
-       </claim>
+       </k>
        <strategy> (SUBST:Map ~> substitute-equals-for-equals)
                => substitute-equals-for-equals
                   ...

--- a/prover/strategies/smt.md
+++ b/prover/strategies/smt.md
@@ -198,7 +198,7 @@ module STRATEGY-SMT
   imports STRATEGIES-EXPORTED-SYNTAX
   imports ML-TO-SMTLIB2
 
-  rule <claim> GOAL </claim>
+  rule <k> GOAL </k>
        <strategy> smt-z3
                => if Z3CheckSAT(Z3Prelude ++SMTLIB2Script ML2SMTLIB(\not(GOAL))) ==K unsat
                   then success
@@ -208,10 +208,10 @@ module STRATEGY-SMT
        </strategy>
        <trace> .K => smt-z3 ... </trace>
 
-  rule <claim> GOAL </claim>
+  rule <k> GOAL </k>
        <strategy> smt-z3 => fail </strategy>
 
-  rule <claim> GOAL </claim>
+  rule <k> GOAL </k>
        <id> GId </id>
        <strategy> smt-cvc4
                => if CVC4CheckSAT(CVC4Prelude ++SMTLIB2Script ML2SMTLIBDecls(GId, \not(GOAL), collectDeclarations(GId))) ==K unsat
@@ -224,7 +224,7 @@ module STRATEGY-SMT
      requires isPredicatePattern(GOAL)
 
 // If the constraints are unsatisfiable, the entire term is unsatisfiable
-  rule <claim> \implies(\and(sep(_), LCONSTRAINTS), _) </claim>
+  rule <k> \implies(\and(sep(_), LCONSTRAINTS), _) </k>
        <id> GId </id>
        <strategy> check-lhs-constraint-unsat
                => if CVC4CheckSAT(CVC4Prelude ++SMTLIB2Script ML2SMTLIBDecls(GId, \and(LCONSTRAINTS), collectDeclarations(GId))) ==K unsat
@@ -241,7 +241,7 @@ module STRATEGY-SMT
 We have an optimized version of trying both: Only call z3 if cvc4 reports unknown.
 
 ```k
-  rule <claim> GOAL </claim>
+  rule <k> GOAL </k>
        <strategy> smt
                => #fun( CVC4RESULT
                      => if CVC4RESULT ==K unsat
@@ -259,7 +259,7 @@ We have an optimized version of trying both: Only call z3 if cvc4 reports unknow
 ```
 
 ```k
-  rule <claim> GOAL </claim>
+  rule <k> GOAL </k>
        <id> GId </id>
        <strategy> smt-debug
                => wait ~> CVC4CheckSAT(CVC4Prelude ++SMTLIB2Script ML2SMTLIBDecls(GId, \not(GOAL), collectDeclarations(GId))):CheckSATResult
@@ -288,12 +288,12 @@ module SMTLIB2-TEST-DRIVER
   imports Z3
   imports CVC4
 
-  configuration <claim> $PGM:Pattern </claim>
+  configuration <k> $PGM:Pattern </k>
                 <smt> .K </smt>
                 <z3> .K </z3>
                 <cvc4> .K </cvc4>
 
-  rule <claim> IMPL </claim>
+  rule <k> IMPL </k>
        <smt> .K => ML2SMTLIB(\not(IMPL)) </smt>
   rule <smt> SCRIPT:SMTLIB2Script </smt>
        <z3> .K => Z3CheckSAT(Z3Prelude ++SMTLIB2Script SCRIPT) </z3>

--- a/prover/strategies/unfolding.md
+++ b/prover/strategies/unfolding.md
@@ -79,19 +79,19 @@ module STRATEGY-UNFOLDING
                   ...
        </strategy>
 
-  rule <claim> \implies(\and(LHS), RHS)
+  rule <k> \implies(\and(LHS), RHS)
         => \implies(\and((LHS -Patterns (LRP, .Patterns)) ++Patterns BODY), RHS)
-       </claim>
+       </k>
        <strategy> left-unfold-oneBody(LRP, \exists { _ } \and(BODY)) => noop ... </strategy>
        <trace> .K => left-unfold-oneBody(LRP, \and(BODY)) ... </trace>
        requires LRP in LHS
 
-  rule <claim> \implies( \and( sep( (LHS => ((LHS -Patterns (LRP, .Patterns)) ++Patterns \and(BODY))) )
+  rule <k> \implies( \and( sep( (LHS => ((LHS -Patterns (LRP, .Patterns)) ++Patterns \and(BODY))) )
                              , _
                              )
                        , RHS
                        )
-       </claim>
+       </k>
        <strategy> left-unfold-oneBody(LRP, \exists { _ } \and(BODY)) => noop ... </strategy>
        <trace> .K => left-unfold-oneBody(LRP, \and(BODY)) ... </trace>
        requires LRP in LHS
@@ -111,7 +111,7 @@ implicatations. The resulting goals are equivalent to the initial goal.
                => left-unfold-Nth-eachLRP(M, getUnfoldables(LHS))
                   ...
        </strategy>
-       <claim> \implies(\and(LHS), RHS) </claim>
+       <k> \implies(\and(LHS), RHS) </k>
 
   rule <strategy> left-unfold-Nth-eachLRP(M, PS)
                => fail
@@ -146,12 +146,12 @@ Note that the resulting goals is stonger than the initial goal (i.e.
                => right-unfold-eachRRP( filterByConstructor(getUnfoldables(RHS), SYMBOL) )
                   ...
        </strategy>
-       <claim> \implies(LHS, \exists { _ } \and(RHS)) </claim>
+       <k> \implies(LHS, \exists { _ } \and(RHS)) </k>
   rule <strategy> right-unfold
                => right-unfold-eachRRP(getUnfoldables(RHS))
                   ...
        </strategy>
-       <claim> \implies(LHS, \exists { _ } \and(RHS)) </claim>
+       <k> \implies(LHS, \exists { _ } \and(RHS)) </k>
   rule <strategy> right-unfold-all(bound: N)
                => right-unfold-all(symbols: getRecursiveSymbols(.Patterns), bound: N)
                   ...
@@ -222,10 +222,10 @@ rule addPattern(P, ListItem(Ps:Patterns) L) => ListItem(P, Ps) addPattern(P, L)
 
 ```k
   // TODO: -Patterns does not work here. We need to substitute RRP with BODY
-  rule <claim> \implies(LHS, \exists { E1 } \and(RHS))
+  rule <k> \implies(LHS, \exists { E1 } \and(RHS))
         => \implies(LHS, \exists { E1 ++Patterns E2 }
                          \and(substPatternsMap(RHS, zip((RRP, .Patterns), (\and(BODY), .Patterns))))) ...
-       </claim>
+       </k>
        <strategy> right-unfold-oneBody(RRP, \exists { E2 } \and(BODY)) => noop ... </strategy>
        <trace> .K
             => right-unfold-oneBody(RRP, \exists { E2 } \and(BODY))
@@ -240,7 +240,7 @@ rule addPattern(P, ListItem(Ps:Patterns) L) => ListItem(P, Ps) addPattern(P, L)
     requires P =/=K #hole:Variable
 
   // right unfolding within an implication context
-  rule <claim> \implies(\and( sep ( \forall { UNIVs => UNIVs ++Patterns E2 }
+  rule <k> \implies(\and( sep ( \forall { UNIVs => UNIVs ++Patterns E2 }
                                     implicationContext( ( \and( sep( #hole
                                                                    , CTXLHS
                                                                    )
@@ -263,7 +263,7 @@ rule addPattern(P, ListItem(Ps:Patterns) L) => ListItem(P, Ps) addPattern(P, L)
                             )
                        , RHS:Pattern
                        )
-       </claim>
+       </k>
        <strategy> right-unfold-oneBody(RRP, \exists { E2 } \and(BODY)) => noop ... </strategy>
        <trace> .K
             => right-unfold-oneBody(RRP, \exists { E2 } \and(BODY))
@@ -291,7 +291,7 @@ or `N` is out of range, `right-unfold(M,N) => fail`.
                => right-unfold-Nth-eachRRP(M, N, getUnfoldables(RHS))
                   ...
        </strategy>
-       <claim> \implies(LHS,\exists {_ } \and(RHS)) </claim>
+       <k> \implies(LHS,\exists {_ } \and(RHS)) </k>
 
   rule <strategy> right-unfold-Nth-eachRRP(M, N, RRPs) => fail ... </strategy>
     requires getLength(RRPs) <=Int M

--- a/prover/t/avl-implies-bst.kore.expected
+++ b/prover/t/avl-implies-bst.kore.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( avl ( H { ArrayIntInt } , X { Int } , F { SetInt } , MIN { Int } , MAX { Int } , Height { Int } , Balance { Int } , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( bst ( H { ArrayIntInt } , X { Int } , F { SetInt } , MIN { Int } , MAX { Int } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/bst-implies-bt.kore.expected
+++ b/prover/t/bst-implies-bt.kore.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( bst ( H { ArrayIntInt } , X { Int } , F { SetInt } , MIN { Int } , MAX { Int } , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( bt ( H { ArrayIntInt } , X { Int } , F { SetInt } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/emptyset-implies-isempty.kore.expected
+++ b/prover/t/emptyset-implies-isempty.kore.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( \equals ( S { SetInt } , emptyset ) , .Patterns ) , \exists { .Patterns } \and ( isEmpty ( S { SetInt } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/fermat-3.smt2.expected
+++ b/prover/t/fermat-3.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( \equals ( plus ( mult ( Vx { Int } , mult ( Vx { Int } , Vx { Int } , .Patterns ) , .Patterns ) , mult ( Vy { Int } , mult ( Vy { Int } , Vy { Int } , .Patterns ) , .Patterns ) , .Patterns ) , mult ( Vz { Int } , mult ( Vz { Int } , Vz { Int } , .Patterns ) , .Patterns ) ) , gt ( Vz { Int } , 0 , .Patterns ) , gt ( Vy { Int } , 0 , .Patterns ) , gt ( Vx { Int } , 0 , .Patterns ) , .Patterns ) , \and ( \or ( .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         fail
       </strategy>

--- a/prover/t/isMod4-implies-isEven.smt2.expected
+++ b/prover/t/isMod4-implies-isEven.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( isDiv4Pos ( Vx { Int } , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( isEvenPos ( Vx { Int } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/listSegmentLeft-implies-listSegmentRight.kore.expected
+++ b/prover/t/listSegmentLeft-implies-listSegmentRight.kore.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( listSegmentLeft ( H { ArrayIntInt } , X { Int } , Y { Int } , F { SetInt } , .Patterns ) , .Patterns ) , \and ( listSegmentRight ( H { ArrayIntInt } , X { Int } , Y { Int } , F { SetInt } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/listSegmentLeft-list-implies-list.kore.expected
+++ b/prover/t/listSegmentLeft-list-implies-list.kore.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( listSegmentLeft ( H { ArrayIntInt } , X { Int } , Y { Int } , F { SetInt } , .Patterns ) , list ( H { ArrayIntInt } , Y { Int } , G { SetInt } , .Patterns ) , \equals ( K { SetInt } , union ( F { SetInt } , G { SetInt } , .Patterns ) ) , disjoint ( F { SetInt } , G { SetInt } , .Patterns ) , .Patterns ) , \and ( list ( H { ArrayIntInt } , X { Int } , K { SetInt } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/listSegmentLeftsorted-sortedlist-implies-sortedlist.kore.expected
+++ b/prover/t/listSegmentLeftsorted-sortedlist-implies-sortedlist.kore.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( listSegmentLeftSorted ( H { ArrayIntInt } , X { Int } , Y { Int } , F { SetInt } , MIN { Int } , MAX { Int } , .Patterns ) , listSorted ( H { ArrayIntInt } , Y { Int } , G { SetInt } , MIN2 { Int } , .Patterns ) , \equals ( K { SetInt } , union ( F { SetInt } , G { SetInt } , .Patterns ) ) , disjoint ( F { SetInt } , G { SetInt } , .Patterns ) , \not ( gt ( MAX { Int } , MIN2 { Int } , .Patterns ) ) , .Patterns ) , \and ( listSorted ( H { ArrayIntInt } , X { Int } , K { SetInt } , MIN { Int } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/listSegmentRight-implies-listSegmentLeft.kore.expected
+++ b/prover/t/listSegmentRight-implies-listSegmentLeft.kore.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( listSegmentRight ( H { ArrayIntInt } , X { Int } , Y { Int } , F { SetInt } , .Patterns ) , .Patterns ) , \and ( listSegmentLeft ( H { ArrayIntInt } , X { Int } , Y { Int } , F { SetInt } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/listSegmentRightLength-appendone-implies-listSegmentRightLength.kore.expected
+++ b/prover/t/listSegmentRightLength-appendone-implies-listSegmentRightLength.kore.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( listSegmentRightLength ( H { ArrayIntInt } , X { Int } , Y { Int } , FA { SetInt } , LA { Int } , .Patterns ) , \equals ( F { SetInt } , union ( FA { SetInt } , singleton ( Y { Int } , .Patterns ) , .Patterns ) ) , disjoint ( FA { SetInt } , singleton ( Y { Int } , .Patterns ) , .Patterns ) , \equals ( Z { Int } , select ( H { ArrayIntInt } , Y { Int } , .Patterns ) ) , \equals ( LENGTH { Int } , plus ( LA { Int } , 1 , .Patterns ) ) , gt ( Y { Int } , 0 , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( listSegmentRightLength ( H { ArrayIntInt } , X { Int } , Z { Int } , F { SetInt } , LENGTH { Int } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/listSortedLength-implies-listLength.kore.expected
+++ b/prover/t/listSortedLength-implies-listLength.kore.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( listSortedLength ( H { ArrayIntInt } , X { Int } , K { SetInt } , MIN { Int } , Length { Int } , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( listLength ( H { ArrayIntInt } , X { Int } , K { SetInt } , Length { Int } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/listSortedLength-implies-listSorted.kore.expected
+++ b/prover/t/listSortedLength-implies-listSorted.kore.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( listSortedLength ( H { ArrayIntInt } , X { Int } , K { SetInt } , MIN { Int } , Length { Int } , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( listSorted ( H { ArrayIntInt } , X { Int } , K { SetInt } , MIN { Int } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/pythagoras.smt2.expected
+++ b/prover/t/pythagoras.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( \equals ( plus ( mult ( Vx { Int } , Vx { Int } , .Patterns ) , mult ( Vy { Int } , Vy { Int } , .Patterns ) , .Patterns ) , mult ( Vz { Int } , Vz { Int } , .Patterns ) ) , gt ( Vz { Int } , 0 , .Patterns ) , gt ( Vy { Int } , 0 , .Patterns ) , gt ( Vx { Int } , 0 , .Patterns ) , .Patterns ) , \and ( \or ( .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         fail
       </strategy>

--- a/prover/t/qf_shid_entl-01.tst.smt2.expected
+++ b/prover/t/qf_shid_entl-01.tst.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( sep ( pto ( Vx { RefGTyp } , c_GTyp ( Vy { RefGTyp } , .Patterns ) , .Patterns ) , RList ( Vy { RefGTyp } , Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( sep ( RList ( Vx { RefGTyp } , Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/qf_shid_entl-02.tst.smt2.expected
+++ b/prover/t/qf_shid_entl-02.tst.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( sep ( RList ( Vx { RefGTyp } , Vy { RefGTyp } , .Patterns ) , RList ( Vy { RefGTyp } , Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( sep ( RList ( Vx { RefGTyp } , Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/qf_shid_entl-03.tst.smt2.expected
+++ b/prover/t/qf_shid_entl-03.tst.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( sep ( List ( Vx { RefGTyp } , Vy { RefGTyp } , .Patterns ) , pto ( Vy { RefGTyp } , c_GTyp ( Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( sep ( List ( Vx { RefGTyp } , Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/qf_shid_entl-04.tst.smt2.expected
+++ b/prover/t/qf_shid_entl-04.tst.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( sep ( List ( Vx { RefGTyp } , Vy { RefGTyp } , .Patterns ) , List ( Vy { RefGTyp } , Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( sep ( List ( Vx { RefGTyp } , Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/qf_shid_entl-05.tst.smt2.expected
+++ b/prover/t/qf_shid_entl-05.tst.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( sep ( PeList ( Vx { RefGTyp } , Vy { RefGTyp } , .Patterns ) , pto ( Vy { RefGTyp } , c_GTyp ( Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( sep ( PeList ( Vx { RefGTyp } , Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/qf_shid_entl-06.tst.smt2.expected
+++ b/prover/t/qf_shid_entl-06.tst.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( sep ( PeList ( Vx { RefGTyp } , Vy { RefGTyp } , .Patterns ) , PeList ( Vy { RefGTyp } , Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( sep ( PeList ( Vx { RefGTyp } , Vz { RefGTyp } , .Patterns ) , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/sortedlist-implies-list.kore.expected
+++ b/prover/t/sortedlist-implies-list.kore.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( listSorted ( H { ArrayIntInt } , X { Int } , K { SetInt } , MIN { Int } , .Patterns ) , .Patterns ) , \exists { .Patterns } \and ( list ( H { ArrayIntInt } , X { Int } , K { SetInt } , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/trivial-var.smt2.expected
+++ b/prover/t/trivial-var.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( .Patterns ) , \and ( \or ( \equals ( Vx { Int } , Vx { Int } ) , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/trivial.smt2.expected
+++ b/prover/t/trivial.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( \equals ( 1 , 1 ) , .Patterns ) , \and ( \or ( \equals ( 2 , 2 ) , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/t/zero-iszero.smt2.expected
+++ b/prover/t/zero-iszero.smt2.expected
@@ -8,9 +8,9 @@
   <goals>
     <goal>
       active: true, id: root, parent: .
-      <claim>
+      <k>
         \implies ( \and ( .Patterns ) , \exists { .Patterns } \and ( iszero ( 0 , .Patterns ) , .Patterns ) )
-      </claim>
+      </k>
       <strategy>
         success
       </strategy>

--- a/prover/utils/load-named.md
+++ b/prover/utils/load-named.md
@@ -14,7 +14,7 @@ module LOAD-NAMED-RULES
        <goal>
          ...
          <id> Name </id>
-         <claim> P </claim>
+         <k> P </k>
          <strategy> success </strategy>
          ...
        </goal>


### PR DESCRIPTION
This has two advantages:

* It is more efficient, since when executing a strategy rules only try matching on the first goal, and not all the goals in the goal cell
* When functions use `local-context`s we no longer need to specify a goalId