### PR TITLE
Fix Kore driver

### DIFF
--- a/prover/drivers/kore-driver.md
+++ b/prover/drivers/kore-driver.md
@@ -68,9 +68,13 @@ in the subgoal and the claim of the named goal remains intact.
        </k>
   rule <k> claim NAME : PATTERN
            strategy STRAT
-        => subgoal(NAME, PATTERN, subgoal(PATTERN, STRAT))
+        => .K
            ...
        </k>
+       <strategy> .K
+               => subgoalNowait(NAME, PATTERN, subgoal(PATTERN, STRAT))
+               ~> goalUp(NAME)
+       </strategy>
 ```
 
 ```k


### PR DESCRIPTION
1. the `subgoal` strategy belongs to the `<strategy>` cell
2. keep the goal containing the `<k>` cell with the declarations on top of the list of all proven goals, so that it can be used process nother declarations after proving the goal - thus supporting multiple goals in a file.